### PR TITLE
Update regex dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,5 @@ license = "MIT"
 documentation = "https://adamcrume.github.io/java-properties"
 
 [dependencies]
-encoding = "^0.2.33"
-regex = "^0.2.1"
+encoding = "0.2.33"
+regex = "1.1.0"


### PR DESCRIPTION
This crate is the only one we still use with a very old version of regex that causes our binary to be larger than necessary. I think it should be safe to update.