### PR TITLE
fix: Add Send and Sync to the error type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,12 +81,12 @@ use std::ops::Deref;
 #[derive(Debug)]
 pub struct PropertiesError {
   description: String,
-  cause: Option<Box<dyn Error + 'static>>,
+  cause: Option<Box<dyn Error + 'static + Send + Sync>>,
   line_number: Option<usize>,
 }
 
 impl PropertiesError {
-  fn new(description: &str, cause: Option<Box<dyn Error + 'static>>, line_number: Option<usize>) -> Self {
+  fn new(description: &str, cause: Option<Box<dyn Error + 'static + Send + Sync>>, line_number: Option<usize>) -> Self {
     PropertiesError {
       description: description.to_string(),
       cause,


### PR DESCRIPTION
Since `PropertiesError` is not `Send` and `Sync`, `anyhow` can not handle it and you will get an error like `the trait 'Sync' is not implemented for '(dyn std::error::Error + 'static)'` when you try to compile the following code.

```rust
use std::io::BufReader;

fn main() -> anyhow::Result<()> {
    let f = std::fs::File::open("/path/to/props")?;
    java_properties::PropertiesIter::new(BufReader::new(f)).read_into(|prop, v| {
        eprintln!("{} {}", prop, v);
    })?;
    Ok(())
}
```

In this PR, `Send` and `Sync` is added to the internal error of `PropertiesError`.