### PR TITLE
Update regex

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ edition = "2018"
 [dependencies]
 encoding = "0.2.33"
 lazy_static = "1.4.0"
-regex = "1.4.1"
+regex = "1.5.5"


### PR DESCRIPTION
Update regex to `1.5.5` as per [security advisory](https://blog.rust-lang.org/2022/03/08/cve-2022-24713.html)