### PR TITLE
Update README example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,24 +6,54 @@ Where the documentation is ambiguous or incomplete, behavior is based on the beh
 
 ## Example
 ```rust
+#![allow(unused)]
+
+use java_properties::read;
+use java_properties::write;
+use java_properties::PropertiesIter;
+use java_properties::PropertiesWriter;
 use std::collections::HashMap;
 use std::env::temp_dir;
 use std::fs::File;
+use std::io::prelude::*;
 use std::io::BufReader;
 use std::io::BufWriter;
-use std::io::prelude::*;
 
-let mut file_name = temp_dir();
-file_name.push("java-properties-test.properties");
+fn main() -> std::result::Result<(), java_properties::PropertiesError> {
+    let mut file_name = temp_dir();
+    file_name.push("java-properties-test.properties");
 
-// Writing
-let mut map1 = HashMap::new();
-map1.insert("a".to_string(), "b".to_string());
-let mut f = File::create(&file_name)?;
-write(BufWriter::new(f), &map1)?;
+    // Writing simple
+    let mut src_map1 = HashMap::new();
+    src_map1.insert("a".to_string(), "b".to_string());
+    let mut f = File::create(&file_name)?;
+    write(BufWriter::new(f), &src_map1)?;
 
-// Reading
-let mut f = File::open(&file_name)?;
-let map2 = read(BufReader::new(f))?;
-assert_eq!(src_map1, dst_map1);
+    // Reading simple
+    let mut f2 = File::open(&file_name)?;
+    let dst_map1 = read(BufReader::new(f2))?;
+    assert_eq!(src_map1, dst_map1);
+
+    // Writing advanced
+    let mut src_map2 = HashMap::new();
+    src_map2.insert("c".to_string(), "d".to_string());
+    let mut f = File::create(&file_name)?;
+    let mut writer = PropertiesWriter::new(BufWriter::new(f));
+    for (k, v) in &src_map2 {
+        writer.write(&k, &v)?;
+    }
+    writer.flush();
+
+    // Reading advanced
+    let mut f = File::open(&file_name)?;
+    let mut dst_map2 = HashMap::new();
+    PropertiesIter::new(BufReader::new(f)).read_into(|k, v| {
+        dst_map2.insert(k, v);
+    })?;
+    assert_eq!(src_map2, dst_map2);
+
+    println!("file: {:#?}", file_name.as_path());
+
+    Ok(())
+}
 ```


### PR DESCRIPTION
When opening this library in `crates.io` and then github, I found the README a bit cryptic, it left out actual usage of this crate.

This PR updates the example code to be fully valid rust code.

This can be tested by running `cargo new test-crate` and adding the contents of the README example to the `main.rs` file.

Changes to example code:
* `#![allow(unused)]` to hide warnings
* add dependencies used
* wrap in main function
* include same code as library example
* order operations to read/write simple then advanced
* output test file to validate results